### PR TITLE
Set Google Maps Iframe Width to 100%. 

### DIFF
--- a/_includes/venue.html
+++ b/_includes/venue.html
@@ -14,7 +14,10 @@
 
     <div class="row">
         <div class="col-sm-12">
-<iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d10503.86698844957!2d2.34765752557971!3d48.839772968588214!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0xcdc898f6f304617b!2sAgroParisTech+Centre+de+Paris+Claude+Bernard!5e0!3m2!1sfr!2sfr!4v1541750408759" width="600" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>
+            <iframe 
+                src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d10503.86698844957!2d2.34765752557971!3d48.839772968588214!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0xcdc898f6f304617b!2sAgroParisTech+Centre+de+Paris+Claude+Bernard!5e0!3m2!1sfr!2sfr!4v1541750408759" 
+                width="100%" height="450" frameborder="0" style="border:0" allowfullscreen>
+            </iframe>
         </div>
     </div>
     


### PR DESCRIPTION
This will prevent it from overflowing it's container on mobile. 